### PR TITLE
eat: 複数プラットフォームでの投稿機能の改善と新機能追加

### DIFF
--- a/src/pages/UserSettingsPage.tsx
+++ b/src/pages/UserSettingsPage.tsx
@@ -232,6 +232,14 @@ export default function UserSettingsPage() {
                     </div>
                   </div>
                 )}
+                {!googleDriveFolderUrl && googleSheetUrl && (
+                  <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-md">
+                    <p className="text-sm text-yellow-800">
+                      Google
+                      Drive画像フォルダが設定されていません。再ログインすると自動的に作成されます。
+                    </p>
+                  </div>
+                )}
               </div>
             ) : (
               <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-md">

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -26,6 +26,8 @@ export type Database = {
           google_drive_folder_id: string | null;
           google_drive_folder_name: string | null;
           google_drive_folder_url: string | null;
+          images_comma_separated: string | null;
+          images_json_array: string | null;
           id: string;
           updated_at: string | null;
           user_id: string | null;
@@ -41,6 +43,8 @@ export type Database = {
           google_drive_folder_id?: string | null;
           google_drive_folder_name?: string | null;
           google_drive_folder_url?: string | null;
+          images_comma_separated?: string | null;
+          images_json_array?: string | null;
           id?: string;
           updated_at?: string | null;
           user_id?: string | null;
@@ -56,6 +60,8 @@ export type Database = {
           google_drive_folder_id?: string | null;
           google_drive_folder_name?: string | null;
           google_drive_folder_url?: string | null;
+          images_comma_separated?: string | null;
+          images_json_array?: string | null;
           id?: string;
           updated_at?: string | null;
           user_id?: string | null;

--- a/supabase/migrations/20241223000001_update_user_settings_for_google_sheets.sql
+++ b/supabase/migrations/20241223000001_update_user_settings_for_google_sheets.sql
@@ -11,6 +11,8 @@ ADD COLUMN IF NOT EXISTS google_sheet_url TEXT,
 ADD COLUMN IF NOT EXISTS google_sheet_id TEXT,
 ADD COLUMN IF NOT EXISTS google_drive_folder_id TEXT,
 ADD COLUMN IF NOT EXISTS google_drive_folder_name TEXT,
-ADD COLUMN IF NOT EXISTS google_drive_folder_url TEXT;
+ADD COLUMN IF NOT EXISTS google_drive_folder_url TEXT,
+ADD COLUMN IF NOT EXISTS images_comma_separated TEXT,
+ADD COLUMN IF NOT EXISTS images_json_array TEXT;
 
 


### PR DESCRIPTION
Google Sheetsへのユーザー設定保存ロジックを修正し、重複エラーを回避

フォーム送信時にプラットフォームごとの投稿を個別に処理

Google Driveの画像フォルダ情報を表示する機能を追加

複数画像の選択・保存機能を追加（カンマ区切りとJSON配列形式）

プラットフォーム別の動的フォームと文字数制限の表示機能を追加

各プラットフォームで利用する画像を個別に設定できる機能を追加

プラットフォームごとの個別スケジュール設定機能を追加