### PR TITLE
ログイン後のリダイレクト先変更と投稿画面のUI・機能改善

### DIFF
--- a/src/components/PostTable.tsx
+++ b/src/components/PostTable.tsx
@@ -24,7 +24,7 @@ interface Post {
   content: string;
   scheduleTime: string;
   platforms: string[];
-  status: "pending" | "sent" | "failed";
+  status: "pending" | "sent" | "failed" | "draft";
   updatedAt: string;
 }
 
@@ -97,8 +97,25 @@ const PostTable: React.FC<PostTableProps> = ({
         return "secondary";
       case "failed":
         return "destructive";
+      case "draft":
+        return "outline";
       default:
         return "default";
+    }
+  };
+
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case "pending":
+        return "予定";
+      case "sent":
+        return "送信済";
+      case "failed":
+        return "失敗";
+      case "draft":
+        return "下書き";
+      default:
+        return status;
     }
   };
 
@@ -106,21 +123,14 @@ const PostTable: React.FC<PostTableProps> = ({
     <Card className="w-full bg-white">
       <CardHeader>
         <CardTitle className="flex justify-between items-center">
-          <span>Posts</span>
+          <span>投稿一覧</span>
           <div className="flex gap-2">
             <Button
               variant="outline"
               size="sm"
               onClick={() => console.log("Filter clicked")}
             >
-              Filter
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => console.log("Bulk actions clicked")}
-            >
-              Bulk Actions
+              フィルター
             </Button>
           </div>
         </CardTitle>
@@ -142,28 +152,28 @@ const PostTable: React.FC<PostTableProps> = ({
                   className="cursor-pointer"
                   onClick={() => handleSort("content")}
                 >
-                  Content
+                  投稿内容
                 </TableHead>
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => handleSort("scheduleTime")}
                 >
-                  Schedule Time
+                  予定時刻
                 </TableHead>
-                <TableHead>Platforms</TableHead>
+                <TableHead>プラットフォーム</TableHead>
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => handleSort("status")}
                 >
-                  Status
+                  ステータス
                 </TableHead>
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => handleSort("updatedAt")}
                 >
-                  Last Updated
+                  最終更新
                 </TableHead>
-                <TableHead className="text-right">Actions</TableHead>
+                <TableHead className="text-right">操作</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -184,7 +194,15 @@ const PostTable: React.FC<PostTableProps> = ({
                       </div>
                     </TableCell>
                     <TableCell>
-                      {new Date(post.scheduleTime).toLocaleString()}
+                      {new Date(post.scheduleTime).toLocaleString("ja-JP", {
+                        timeZone: "Asia/Tokyo",
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit",
+                      })}
                     </TableCell>
                     <TableCell>
                       <div className="flex gap-1">
@@ -197,11 +215,19 @@ const PostTable: React.FC<PostTableProps> = ({
                     </TableCell>
                     <TableCell>
                       <Badge variant={getStatusBadgeVariant(post.status)}>
-                        {post.status}
+                        {getStatusText(post.status)}
                       </Badge>
                     </TableCell>
                     <TableCell>
-                      {new Date(post.updatedAt).toLocaleString()}
+                      {new Date(post.updatedAt).toLocaleString("ja-JP", {
+                        timeZone: "Asia/Tokyo",
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit",
+                      })}
                     </TableCell>
                     <TableCell className="text-right">
                       <DropdownMenu>
@@ -214,15 +240,15 @@ const PostTable: React.FC<PostTableProps> = ({
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem onClick={() => onEdit(post.id)}>
                             <Edit className="mr-2 h-4 w-4" />
-                            Edit
+                            編集
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => onDelete(post.id)}>
                             <Trash2 className="mr-2 h-4 w-4" />
-                            Delete
+                            削除
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => onRefresh(post.id)}>
                             <RefreshCw className="mr-2 h-4 w-4" />
-                            Refresh Status
+                            ステータス更新
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
@@ -232,7 +258,7 @@ const PostTable: React.FC<PostTableProps> = ({
               ) : (
                 <TableRow>
                   <TableCell colSpan={7} className="text-center py-8">
-                    No posts found. Create your first post!
+                    投稿が見つかりません。最初の投稿を作成してください！
                   </TableCell>
                 </TableRow>
               )}
@@ -248,8 +274,7 @@ const PostTable: React.FC<PostTableProps> = ({
 const defaultPosts: Post[] = [
   {
     id: "1",
-    content:
-      "Exciting news! We just launched our new product. Check it out at our website!",
+    content: "新商品を発表しました！詳細はウェブサイトをご確認ください。",
     scheduleTime: "2023-06-15T10:00:00",
     platforms: ["x", "facebook"],
     status: "sent",
@@ -257,8 +282,7 @@ const defaultPosts: Post[] = [
   },
   {
     id: "2",
-    content:
-      "Join us for our upcoming webinar on digital marketing strategies for small businesses.",
+    content: "中小企業向けデジタルマーケティング戦略のウェビナーを開催します。",
     scheduleTime: "2023-06-20T14:00:00",
     platforms: ["x", "instagram", "linkedin"],
     status: "pending",
@@ -266,11 +290,19 @@ const defaultPosts: Post[] = [
   },
   {
     id: "3",
-    content: "We're hiring! Looking for talented developers to join our team.",
+    content: "採用情報：優秀な開発者を募集しています。",
     scheduleTime: "2023-06-18T12:00:00",
     platforms: ["linkedin", "x"],
     status: "failed",
     updatedAt: "2023-06-18T12:01:00",
+  },
+  {
+    id: "4",
+    content: "下書きの投稿です。後で編集予定。",
+    scheduleTime: "2023-06-25T15:00:00",
+    platforms: ["x"],
+    status: "draft",
+    updatedAt: "2023-06-20T12:00:00",
   },
 ];
 

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -54,7 +54,7 @@ interface Post {
   scheduleTime: string;
   platforms: string[];
   channels?: string[];
-  status: "pending" | "sent" | "failed";
+  status: "pending" | "sent" | "failed" | "draft";
   updatedAt: string;
   imageUrl?: string;
 }
@@ -223,14 +223,8 @@ const Home = () => {
           navigate("/login", { replace: true });
         } else {
           setUser(user);
-          // Handle sheet creation for Google OAuth users only once
-          if (
-            !sheetCreationHandled.current &&
-            user.app_metadata?.provider === "google"
-          ) {
-            sheetCreationHandled.current = true;
-            await handleSheetCreationOnLogin();
-          }
+          // No longer auto-create sheets on login - redirect to dashboard instead
+          // Users will create sheets manually from the dashboard
         }
       } catch (error) {
         console.error("Authentication check failed:", error);
@@ -254,14 +248,8 @@ const Home = () => {
         navigate("/login", { replace: true });
       } else if (event === "SIGNED_IN" && session?.user) {
         setUser(session.user);
-        // Handle sheet creation for Google OAuth users only once
-        if (
-          !sheetCreationHandled.current &&
-          session.user.app_metadata?.provider === "google"
-        ) {
-          sheetCreationHandled.current = true;
-          await handleSheetCreationOnLogin();
-        }
+        // No longer auto-create sheets on login - redirect to dashboard instead
+        // Users will create sheets manually from the dashboard
       }
     });
 
@@ -599,6 +587,9 @@ const Home = () => {
           postId,
           imageUrl: post.imageUrl,
         });
+        // Set image load error message for edit mode
+        postForEdit.imageLoadError =
+          "選択された画像が取得できません。再度設定してください。";
       }
 
       setCurrentPost(postForEdit);
@@ -760,6 +751,9 @@ const Home = () => {
             </Badge>
             <Badge variant="outline" className="bg-red-100">
               失敗: {posts.filter((post) => post.status === "failed").length}
+            </Badge>
+            <Badge variant="outline" className="bg-gray-100">
+              下書き: {posts.filter((post) => post.status === "draft").length}
             </Badge>
           </div>
           <PostTable

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1005,7 +1005,8 @@ export const fetchPostsFromGoogleSheet = async () => {
           content: row[1] || "",
           platforms: [], // Use platforms instead of channels
           scheduleTime: jstTime.toISOString(),
-          status: (row[4] as "pending" | "sent" | "failed") || "pending",
+          status:
+            (row[4] as "pending" | "sent" | "failed" | "draft") || "pending",
           imageUrl: row[5] || "",
           updatedAt: row[10] || row[9] || new Date().toISOString(), // Updated at is at index 10
         });

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -134,7 +134,7 @@ export default function DashboardPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <PlusCircle className="h-5 w-5" />
-                投稿作成
+                投稿作成・管理
               </CardTitle>
               <CardDescription>新しいSNS投稿を作成</CardDescription>
             </CardHeader>
@@ -154,8 +154,9 @@ export default function DashboardPage() {
             </CardHeader>
             <CardContent>
               <p className="text-muted-foreground">
-                SNS投稿管理システムへようこそ。まずはユーザー設定でGoogle連携とAI連携を設定してください。
-                設定完了後、Google Sheetsを作成して投稿管理を開始できます。
+                SNS投稿管理システムへようこそ。まずはGoogle Sheet・Google Drive
+                Folderの作成から初めてください。AI設定は、ユーザ設定ページで行います。（AI設定は任意です。）
+                設定完了後、投稿管理を開始できます。
               </p>
             </CardContent>
           </Card>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -35,7 +35,7 @@ export default function LoginPage() {
         data: { user },
       } = await supabase.auth.getUser();
       if (user) {
-        navigate("/", { replace: true });
+        navigate("/dashboard", { replace: true });
       }
     };
     checkUser();
@@ -47,7 +47,7 @@ export default function LoginPage() {
       if (event === "SIGNED_IN" && session) {
         // Wait a bit to ensure the session is fully established
         setTimeout(() => {
-          navigate("/", { replace: true });
+          navigate("/dashboard", { replace: true });
         }, 100);
       }
     });
@@ -89,8 +89,8 @@ export default function LoginPage() {
           description: "テストユーザーでログインしました",
         });
 
-        // Navigate to home page
-        navigate("/", { replace: true });
+        // Navigate to dashboard page
+        navigate("/dashboard", { replace: true });
         return;
       } catch (error) {
         toast({
@@ -135,7 +135,7 @@ export default function LoginPage() {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}/`,
+          redirectTo: `${window.location.origin}/dashboard`,
           scopes:
             "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/spreadsheets",
         },


### PR DESCRIPTION
ログイン成功後のリダイレクト先を/dashboardに統一
Google Sheets作成ページの機能とUIを更新
投稿テーブルの時刻表示をJSTに修正し、日本語化
下書きステータスを追加し、「下書き保存」ボタンを実装
編集モードでのプラットフォーム変更を無効化
編集モードでの画像読み込みエラーハンドリングを追加
Bulk Actionsボタンを削除